### PR TITLE
Fix viteProjectPath for dependencies outside the project root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 //@ts-expect-error typing isn't provided
 import nodeElmcompiler from 'node-elm-compiler'
-import { normalize, relative } from 'path'
+import { normalize } from 'path'
 import type { ModuleNode, Plugin } from 'vite'
 import { injectHMR } from './hmrInjector.js'
 import { acquireLock } from './mutex.js'
@@ -8,7 +8,7 @@ import { parseOptions } from './pluginOptions.js'
 import { compile } from './compiler.js'
 
 const trimDebugMessage = (code: string): string => code.replace(/(console\.warn\('Compiled in DEBUG mode)/, '// $1')
-const viteProjectPath = (dependency: string) => `/${relative(process.cwd(), dependency)}`
+const viteProjectPath = (dependency: string) => `/@fs${normalize(dependency)}`
 
 const parseImportId = (id: string) => {
   const parsedId = new URL(id, 'file://')


### PR DESCRIPTION
viteProjectPath built HMR accept() specifiers as `/` + the path relative to process.cwd(), e.g. `/app/src/elm/Foo.elm`. That only resolves when the Elm source lives inside Vite's project root. When it's built from a Vite root elsewhere in the repo (e.g. a separate dev-server package), the relative path escapes the root or lands on a nonexistent path.

Newer Vite (8+) eagerly resolves the specifiers passed to import.meta.hot.accept([...]) during import analysis, so an unresolvable path now fails outright (HTTP 500) instead of just being inert. Older Vite didn't validate accept() specifiers eagerly, so this was previously latent.

Emit the `/@fs/<abs-path>` form Vite already uses for files outside the project root, which resolves correctly regardless of where the Elm source sits relative to the project root.